### PR TITLE
BUGFIX: any pronouns break add_message

### DIFF
--- a/chat.html
+++ b/chat.html
@@ -595,7 +595,11 @@
             user = user.toLowerCase();
 
             if (config['ui']['pronouns'] === true && (user in pronouns_users && pronouns_users[user] !== undefined)) {
-                return pronouns.filter(p => p.name === pronouns_users[user]['pronoun_id'])[0].display;
+                if (pronouns_users[user]['pronoun_id'] === "any") {
+                    return "Any";
+                } else {
+                    return pronouns.filter(p => p.name === pronouns_users[user]['pronoun_id'])[0].display;
+                }
             } else {
                 return false;
             }


### PR DESCRIPTION
Due to how "any" pronouns don't have any definition in the list of pronouns they ran into an error. Fixed by hardcoding how "any" is handled - not a cute solution but ig it works better than before...